### PR TITLE
docs: ensure script is executable after copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ volumes and bind mounts in Docker Compose services.
 
 To use it in your own project, copy the `.devcontainer` directory from this
 repository into your project and edit the `devcontainer.json` and
-`docker-compose.yml` as required.
+`docker-compose.yml` as required. Make sure the
+`.devcontainer/gen-docker-compose-workspace-env.sh` script is marked executable
+(`chmod +x ...`).
 
 The key parts are:
 


### PR DESCRIPTION
The gen-docker-compose-workspace-env.sh is executable in the repo, but
may need to be made executable if the files are manually copied, rather
than cloned from the repo.

This fixes #1.